### PR TITLE
feat/ci: native arm64 build

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -15,7 +15,7 @@ jobs:
             arch: ARM64
     runs-on: ${{ matrix.runner }}
     container:
-      image: ghcr.io/vanilla-os/pico:main
+      image: ghcr.io/vanilla-os/pico:latest
       volumes:
         - /proc:/proc
         - /:/run/host

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -35,5 +35,5 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: VanillaOS 2 Orchid ${{ matrix.arch }} ${{ env.CURRENT_DATE }}
+        name: Vanilla OS ${{ matrix.arch }} ${{ env.CURRENT_DATE }}
         path: builds/

--- a/.github/workflows/orchid.yml
+++ b/.github/workflows/orchid.yml
@@ -5,7 +5,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: AMD64
+          - runner: ubuntu-24.04-arm
+            arch: ARM64
+    runs-on: ${{ matrix.runner }}
     container:
       image: ghcr.io/vanilla-os/pico:main
       volumes:
@@ -27,5 +35,5 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: VanillaOS 2 Orchid ${{ env.CURRENT_DATE }}
+        name: VanillaOS 2 Orchid ${{ matrix.arch }} ${{ env.CURRENT_DATE }}
         path: builds/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       if: github.repository == 'vanilla-os/live-iso'
       working-directory: amd64
       run: |
-        gh release upload "2.0" *.iso *.txt --clobber --repo vanilla-os/live-iso
+        gh release upload "3.0" *.iso *.txt --clobber --repo vanilla-os/live-iso
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,7 @@ build () {
   YYYYMMDD="$(date +%Y%m%d)"
   OUTPUT_DIR="$BASE_DIR/builds/$BUILD_ARCH"
   mkdir -p "$OUTPUT_DIR"
-  FNAME="VanillaOS-$VERSION-$CHANNEL-$BUILD_ARCH.$YYYYMMDD$OUTPUT_SUFFIX"
+  FNAME="Vanilla-OS-$VERSION-$CHANNEL-$BUILD_ARCH.$YYYYMMDD$OUTPUT_SUFFIX"
   mv $BASE_DIR/tmp/$BUILD_ARCH/live-image-$BUILD_ARCH.hybrid.iso "$OUTPUT_DIR/${FNAME}.iso"
 
   # cd into output to so {FNAME}.sha256.txt only

--- a/build.sh
+++ b/build.sh
@@ -73,8 +73,8 @@ build () {
   YYYYMMDD="$(date +%Y%m%d)"
   OUTPUT_DIR="$BASE_DIR/builds/$BUILD_ARCH"
   mkdir -p "$OUTPUT_DIR"
-  FNAME="VanillaOS-$VERSION-$CHANNEL.$YYYYMMDD$OUTPUT_SUFFIX"
-  mv $BASE_DIR/tmp/amd64/live-image-amd64.hybrid.iso "$OUTPUT_DIR/${FNAME}.iso"
+  FNAME="VanillaOS-$VERSION-$CHANNEL-$BUILD_ARCH.$YYYYMMDD$OUTPUT_SUFFIX"
+  mv $BASE_DIR/tmp/$BUILD_ARCH/live-image-$BUILD_ARCH.hybrid.iso "$OUTPUT_DIR/${FNAME}.iso"
 
   # cd into output to so {FNAME}.sha256.txt only
   # includes the filename and not the path to
@@ -85,8 +85,8 @@ build () {
   cd $BASE_DIR
 }
 
-if [[ "$ARCH" == "all" ]]; then
-    build amd64
+if [[ -z "$ARCH" ]]; then
+    build "$(dpkg --print-architecture)"
 else
     build "$ARCH"
 fi

--- a/etc/config/bootloaders/grub-pc/grub.cfg
+++ b/etc/config/bootloaders/grub-pc/grub.cfg
@@ -10,17 +10,17 @@ set menu_color_normal=white/black
 set menu_color_highlight=black/light-gray
 
 set timeout=5
-menuentry "Install Vanilla OS 2" {
+menuentry "Install Vanilla OS 3" {
  set gfxpayload=keep
  linux	KERNEL_LIVE APPEND_LIVE ---
  initrd INITRD_LIVE
 }
-menuentry "Install Vanilla OS 2 (Safe Graphics)" {
+menuentry "Install Vanilla OS 3 (Safe Graphics)" {
  set gfxpayload=keep
  linux	KERNEL_LIVE APPEND_LIVE nomodeset ---
  initrd INITRD_LIVE
 }
-menuentry "Install Vanilla OS 2 (Nouveau unloaded)" {
+menuentry "Install Vanilla OS 3 (Nouveau unloaded)" {
  set gfxpayload=keep
  linux	KERNEL_LIVE APPEND_LIVE modprobe.blacklist=nouveau ---
  initrd INITRD_LIVE

--- a/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
+++ b/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
@@ -38,7 +38,6 @@ expect
 cifs-utils
 xfsprogs
 jfsutils
-reiserfsprogs
 lvm2
 wamerican
 fwupdate
@@ -91,7 +90,6 @@ orca
 brltty
 espeak-ng
 at-spi2-core
-mousetweaks
 speech-dispatcher
 speech-dispatcher-espeak-ng
 gparted

--- a/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
+++ b/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
@@ -8,7 +8,6 @@ squashfs-tools
 cryptsetup
 
 shim-signed
-shim-helpers-amd64-signed
 
 firmware-linux
 firmware-linux-nonfree
@@ -19,10 +18,19 @@ firmware-atheros
 firmware-b43-installer
 firmware-brcm80211
 firmware-sof-signed
-intel-microcode
-amd64-microcode
 b43-fwcutter
 spice-webdavd
+
+#if ARCHITECTURES amd64
+shim-helpers-amd64-signed
+
+intel-microcode
+amd64-microcode
+#endif
+
+#if ARCHITECTURES arm64
+shim-helpers-arm64-signed
+#endif
 
 ca-certificates
 btrfs-progs
@@ -95,5 +103,8 @@ plymouth-themes
 open-vm-tools
 open-vm-tools-desktop
 qemu-guest-agent
+
+#if ARCHITECTURES amd64
 virtualbox-guest-utils
 virtualbox-guest-x11
+#endif

--- a/etc/config/package-lists.vanilla-installer/pool.list.binary
+++ b/etc/config/package-lists.vanilla-installer/pool.list.binary
@@ -2,14 +2,25 @@ b43-fwcutter
 firmware-b43-installer
 firmware-brcm80211
 dkms
-intel-microcode
-iucode-tool
 setserial
 user-setup
 
 efibootmgr
+shim-signed
+
+#if ARCHITECTURES amd64
+intel-microcode
+iucode-tool
+
 grub-efi-amd64
 grub-efi-amd64-bin
 grub-efi-amd64-signed
-shim-signed
 shim-helpers-amd64-signed
+#endif
+
+#if ARCHITECTURES arm64
+grub-efi-arm64
+grub-efi-arm64-bin
+grub-efi-arm64-signed
+shim-helpers-arm64-signed
+#endif

--- a/etc/terraform.conf
+++ b/etc/terraform.conf
@@ -5,10 +5,10 @@ ARCH=""
 BASECODENAME="sid"
 
 # distribution codename
-CODENAME="orchid"
+CODENAME="reunion"
 
 # distribution version
-VERSION="2"
+VERSION="3"
 
 # distribution channel
 CHANNEL="stable"

--- a/etc/terraform.conf
+++ b/etc/terraform.conf
@@ -17,7 +17,7 @@ CHANNEL="stable"
 NAME="Vanilla OS"
 
 # mirror to fetch packages from
-MIRROR_URL="https://repo3.vanillaos.org/20251129T023004Z"
+MIRROR_URL="https://repo3.vanillaos.org/20260706T022345Z"
 
 # suffix for generated .iso files
 OUTPUT_SUFFIX=""

--- a/etc/terraform.conf
+++ b/etc/terraform.conf
@@ -1,5 +1,5 @@
-# target architecture - i386, arm64 or all
-ARCH="amd64"
+# target architecture - i386, amd64, arm64, or leave empty to use host architecture
+ARCH=""
 
 # base codename
 BASECODENAME="sid"


### PR DESCRIPTION
This PR introduces native ARM64 support for building live ISO in GitHub Actions.

Resolves https://github.com/Vanilla-OS/live-iso/issues/87.

### Requirements:
1. https://github.com/Vanilla-OS/Albius/pull/95 be merged.
2. ARM64 packages be available in https://repo2.vanillaos.org, or use the official Debian sid repo as an alternative.