### PR TITLE
fix: install intel, mediatek and nvidia firmware explicitly

### DIFF
--- a/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
+++ b/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
@@ -18,6 +18,10 @@ firmware-atheros
 firmware-b43-installer
 firmware-brcm80211
 firmware-sof-signed
+firmware-intel-graphics
+firmware-intel-misc
+firmware-mediatek
+firmware-nvidia-graphics
 b43-fwcutter
 spice-webdavd
 


### PR DESCRIPTION
Related to Vanilla-OS/core-image#163.