### PR TITLE
feat: clean up packages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,7 @@ build () {
 # LIVE-BUILD BUILD #
 #------------------#
 "
-  lb build
+  MKSQUASHFS_OPTIONS="-b 1048576" lb build
 
   echo -e "
 #---------------------------#

--- a/etc/auto/config
+++ b/etc/auto/config
@@ -25,6 +25,7 @@ lb config noauto \
     --mirror-binary "$MIRROR_URL" \
     \
     --keyring-packages debian-keyring \
+    --apt-indices false \
     --apt-options "--yes --option Acquire::Check-Valid-Until=false --option Acquire::Retries=5 --option Acquire::http::Timeout=100" \
     --apt-recommends true \
     --apt-source-archives false \

--- a/etc/config/hooks/live/000-remove-blacklisted-packages.chroot
+++ b/etc/config/hooks/live/000-remove-blacklisted-packages.chroot
@@ -4,9 +4,8 @@
 echo "P: Begin executing remove-blacklisted-packages chroot hook..."
 
 apt-get autoremove --purge -f -q -y \
-    apport \
-    snapd \
-    update-notifier
+    containernetworking-plugins \
+    papers
 
 # fake desktop entries to prevent some applications from displaying
 mkdir -p /etc/skel/.local/share/applications

--- a/etc/config/hooks/live/999-cleanup-apt-cache.chroot
+++ b/etc/config/hooks/live/999-cleanup-apt-cache.chroot
@@ -1,7 +1,0 @@
-#!/bin/sh
-# Description: Cleanup apt cache files that add ~100MB to the .iso and aren't needed
-
-rm -f /var/lib/apt/lists/*_Packages
-rm -f /var/lib/apt/lists/*_Sources
-rm -f /var/lib/apt/lists/*_Translation-*
-

--- a/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
+++ b/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
@@ -44,7 +44,6 @@ xfsprogs
 jfsutils
 lvm2
 wamerican
-fwupdate
 mokutil
 rsync
 sudo
@@ -53,11 +52,9 @@ zstd
 ntpsec
 
 gdm3
-xorg
 
 gnome-shell
 gnome-session
-gnome-browser-connector
 gnome-disk-utility
 gnome-control-center
 gnome-console
@@ -68,14 +65,9 @@ modemmanager
 bluez
 
 epiphany-browser
-xdg-desktop-portal-gnome
 evolution-data-server
 mutter
-gjs
 
-fonts-cantarell
-fonts-dejavu-core
-fonts-freefont-ttf
 fonts-noto-color-emoji
 fonts-indic
 fonts-kacst-one
@@ -98,7 +90,7 @@ speech-dispatcher
 speech-dispatcher-espeak-ng
 gparted
 
-podman
+golang-github-containers-common
 
 plymouth-themes
 
@@ -108,5 +100,4 @@ qemu-guest-agent
 
 #if ARCHITECTURES amd64
 virtualbox-guest-utils
-virtualbox-guest-x11
 #endif


### PR DESCRIPTION
This PR brings the ISO size down to under 2 GB. Key changes include:

1. Removed packages that are not directly used.
2. Replaced the full `podman` package with `golang-github-containers-common` for Albius, and explicitly removed `containernetworking-plugins`.
3. Increased the XZ block size to 1M.